### PR TITLE
Update Get-MaintenancePlanDetails.ps1

### DIFF
--- a/Get-MaintenancePlanDetails.ps1
+++ b/Get-MaintenancePlanDetails.ps1
@@ -1,4 +1,5 @@
 #requires -modules dbatools
+#requires -Version 5.1
 function Get-MaintenancePlanDetails {
     <#
         .SYNOPSIS


### PR DESCRIPTION
This function uses Enums which are available in version 5.1 onwards.
Rather than rewrite the function to remove the Enums, I'm going to take the quick win and ensure that the script requires PowerShell version 5.1 onwards.